### PR TITLE
Update codemirror.dart

### DIFF
--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -124,6 +124,11 @@ class CodeMirror extends ProxyHolder {
    */
   CodeMirror.fromElement(Element element, {Map options}) :
       super(_createFromElement(element, options));
+      
+  /**
+   * Create a new CodeMirror editor from the given JsObject.
+   */
+  CodeMirror.fromJsObject(JsObject object) : super(object);
 
   /**
    * Fires every time the content of the editor is changed.


### PR DESCRIPTION
Added new CodeMirror constructor in order to create an instance from a JsObject. This is needed when the CodeMirror instance is returned as Helper function parameter (like for the hint case).
