### PR TITLE
Expose execCommand

### DIFF
--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -337,6 +337,10 @@ class CodeMirror extends ProxyHolder {
     };
   }
 
+  void execCommand(String name) {
+    callArg('execCommand', name);
+  }
+
   /**
    * Sets the gutter marker for the given gutter (identified by its CSS class,
    * see the gutters option) to the given value. Value can be either null, to


### PR DESCRIPTION
Not sure if this was intentionally hidden. I've been using it to implement copy/cut/paste in a right click context menu in a chrome app.