### PR TITLE
fixed Doc.getModeAt

### DIFF
--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -981,7 +981,7 @@ class Doc extends ProxyHolder {
    *
    * The returned mode is a `JsObject`.
    */
-  dynamic getModeAt(Position pos) => callArg('getMode', pos.toProxy());
+  dynamic getModeAt(Position pos) => getEditor().callArg('getModeAt', pos.toProxy());
 
   /**
    * Fetches the line handle for the given line number.

--- a/test/all.dart
+++ b/test/all.dart
@@ -5,6 +5,7 @@
 library codemirror.tests;
 
 import 'dart:html';
+import 'dart:js';
 
 import 'package:codemirror/codemirror.dart';
 import 'package:unittest/html_config.dart';
@@ -27,6 +28,7 @@ void main() {
   group('CodeMirror', createCodeMirrorTests);
   group('CodeMirror (static) ', createCodeMirrorStaticTests);
   group('Doc', createDocTests);
+  group('HtmlDoc', createHtmlDocTests);
   group('history', createHistoryTests);
 }
 
@@ -123,6 +125,26 @@ createDocTests() {
     expect(doc.getLine(0), 'one');
     expect(doc.getLine(1), 'two');
     expect(doc.getLine(2), 'three');
+  });
+}
+
+createHtmlDocTests() {
+  CodeMirror editor;
+
+  setUp(() {
+    editor = new CodeMirror.fromElement(editorHost, options: {"mode": "text/html"});
+  });
+
+  tearDown(() {
+    editor.dispose();
+    editorHost.children.clear();
+  });
+
+  test('getModeAt', () {
+    Doc doc = editor.getDoc();
+    doc.setValue('<style>\np {color: black;}\n</style>');
+    JsObject mode = doc.getModeAt(new Position(2,0));
+    expect(mode['name'], 'css');
   });
 }
 


### PR DESCRIPTION
Fixed a typo. And it seems like getModeAt is only available from CodeMirror, and not from Doc, so I tried to fix that as well. 