### PR TITLE
Custom commands with multiple editors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Arron Washington <arron@theradicaledwards.com>
 Federico De Faveri <defaveri@gmail.com>
 Greg Lowe <greg.lowe@gmail.com>
 Kasper Peulen <kasperpeulen@gmail.com>
+Justin Andresen <jan.dresen.95@gmail.com>

--- a/example/simple.dart
+++ b/example/simple.dart
@@ -76,7 +76,7 @@ void main() {
   editor.refresh();
   editor.focus();
 
-  editor.addCommand('find', (foo) {
+  CodeMirror.addCommand('find', (foo) {
     /*LineHandle handle =*/ editor.getDoc().getLineHandle(editor.getCursor().line);
 
     print('todo: handle find');

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -147,6 +147,16 @@ class CodeMirror extends ProxyHolder {
     return _cm.callMethod('fromTextArea', args);
   }
 
+  /**
+  * Add a new custom command to CodeMirror.
+  */
+  static void addCommand(String name, CommandHandler callback) {
+    _cm['commands'][name] = (JsObject obj) {
+      var editor = new CodeMirror.fromJsObject(obj);
+      callback(editor);
+    };
+  }
+
   Doc _doc;
 
   /**
@@ -362,16 +372,6 @@ class CodeMirror extends ProxyHolder {
    */
   Position getCursor([String start]) => new Position.fromProxy(
         start == null ? call('getCursor') : callArg('getCursor', start));
-
-  /**
-   * Add a new custom command to CodeMirror.
-   */
-  void addCommand(String name, CommandHandler callback) {
-    _cm['commands'][name] = (JsObject obj) {
-      var editor = new CodeMirror.fromJsObject(obj);
-      callback(editor);
-    };
-  }
 
   /**
    * Runs the command with the given name on the editor.

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -367,8 +367,9 @@ class CodeMirror extends ProxyHolder {
    * Add a new custom command to CodeMirror.
    */
   void addCommand(String name, CommandHandler callback) {
-    _cm['commands'][name] = (_) {
-      callback(this);
+    _cm['commands'][name] = (JsObject obj) {
+      var editor = new CodeMirror.fromJsObject(obj);
+      callback(editor);
     };
   }
 


### PR DESCRIPTION
It is currently not possible to use the same custom command across more than one editor.
This is because `addCommand` ignores the argument CodeMirror passes to the handler. The callback  receives therefore always an instance of the editor `addCommand` was called with.

These changes make sure that multiple editors can share a custom command.
Additionally `addCommand` no longer depends on `this` and can therefore be declared `static`.
As a result the example needed to be updated.