### PR TITLE
Expose methods for multiple selections.

### DIFF
--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -701,6 +701,13 @@ class Doc extends ProxyHolder {
   }
 
   /**
+   * Returns an array containing a string for each selection, representing the
+   * content of the selections.
+   */
+  Iterable<String> getSelections([String lineSep]) =>
+      callArg('getSelections', lineSep);
+
+  /**
    * Replace the part of the document between [from] and [to] with the given
    * string. [to] can be left off to simply insert the string at position
    * [from].

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -708,6 +708,23 @@ class Doc extends ProxyHolder {
       callArg('getSelections', lineSep);
 
   /**
+   * Sets a new set of selections. There must be at least one selection in the
+   * given array. When [primary] is a number, it determines which selection is
+   * the primary one. When it is not given, the primary index is taken from
+   * the previous selection, or set to the last range if the previous
+   * selection had less ranges than the new one. Supports the same
+   * options as [setSelection].
+   */
+  void setSelections(Iterable<Span> ranges, {int primary, Map options}) {
+    callArgs('setSelections', [new JsArray.from(ranges.map((Span range) {
+      return new JsObject.jsify({
+        'anchor': range.anchor.toProxy(),
+        'head': range.head?.toProxy()
+      });
+    })), primary, options]);
+  }
+
+  /**
    * Replace the part of the document between [from] and [to] with the given
    * string. [to] can be left off to simply insert the string at position
    * [from].

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -725,6 +725,17 @@ class Doc extends ProxyHolder {
   }
 
   /**
+   * The length of the given array should be the same as the number of active
+   * selections. Replaces the content of the selections with the strings in
+   * the array. The select argument works the same as in [replaceSelection].
+   */
+  void replaceSelections(Iterable<String> replacement, {String select}) {
+    callArgs('replaceSelections', select != null ?
+        [new JsObject.jsify(replacement), select] :
+        [new JsObject.jsify(replacement)]);
+  }
+
+  /**
    * Replace the part of the document between [from] and [to] with the given
    * string. [to] can be left off to simply insert the string at position
    * [from].

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -736,6 +736,20 @@ class Doc extends ProxyHolder {
   }
 
   /**
+   * Retrieves a list of all current selections.
+   *
+   * These will always be sorted,
+   * and never overlap (overlapping selections are merged). Each object in the
+   * array contains `anchor` and `head` properties referring
+   * to `{line, ch}` objects.
+   */
+  Iterable<Span> listSelections() {
+    return call('listSelections').map((JsObject selection) {
+      return new Span.fromProxy(selection);
+    });
+  }
+
+  /**
    * Replace the part of the document between [from] and [to] with the given
    * string. [to] can be left off to simply insert the string at position
    * [from].

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -652,6 +652,11 @@ class Doc extends ProxyHolder {
   String getLine(int n) => callArg('getLine', n);
 
   /**
+   * Return `true` if any text is selected.
+   */
+  bool somethingSelected() => call('somethingSelected');
+
+  /**
    * Get the currently selected code. Optionally pass a line separator to put
    * between the lines in the output. When multiple selections are present, they
    * are concatenated with instances of [lineSep] in between.


### PR DESCRIPTION
CodeMirror supports multi-selection by ctrl-clicking.
Methods to retrieve and modify single selections exist already. Their variations to handle multi-selection should be exposed as well.