### PR TITLE
Comparable position.

### DIFF
--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -1088,7 +1088,7 @@ class Doc extends ProxyHolder {
  *
  * `{line, ch}`
  */
-class Position {
+class Position implements Comparable<Position> {
   final int line;
   final int ch;
 
@@ -1102,6 +1102,11 @@ class Position {
       line == other.line && ch == other.ch;
 
   int get hashCode => (line << 8 | ch).hashCode;
+
+  int compareTo(Position other) {
+    if (line == other.line) return ch - other.ch;
+    return line - other.line;
+  }
 
   String toString() => '[${line}:${ch}]';
 }

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -1108,6 +1108,11 @@ class Position implements Comparable<Position> {
     return line - other.line;
   }
 
+  operator<(Position other) => compareTo(other) < 0;
+  operator<=(Position other) => compareTo(other) <= 0;
+  operator>=(Position other) => compareTo(other) >= 0;
+  operator>(Position other) => compareTo(other) > 0;
+
   String toString() => '[${line}:${ch}]';
 }
 


### PR DESCRIPTION
I've encountered that having to tell whether the cursor is before or after a certain position in the document or the `head`/`anchor` of a selection comes first is a common problem.
Currently it's necessary to test both the `line` and `ch` property of a `Position` object.
That's why I think it would be advantageous if `Position` implemented the `Comparable` interface and overloaded the relational operators in addition to `operator==`. 