### PR TITLE
Add separator arguments to `Doc.getRange` and `Doc.getValue`

### DIFF
--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -625,8 +625,15 @@ class Doc extends ProxyHolder {
     return _editor;
   }
 
-  String getValue() => call('getValue');
+  /**
+   * Get the current editor content. You can pass it an optional argument to
+   * specify the string to be used to separate lines (defaults to "\n").
+   */
+  String getValue([String separator = '\n']) => callArg('getValue', separator);
 
+  /**
+   * Set the editor content.
+   */
   void setValue(String value) => callArg('setValue', value);
 
   /**

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -629,7 +629,7 @@ class Doc extends ProxyHolder {
    * Get the current editor content. You can pass it an optional argument to
    * specify the string to be used to separate lines (defaults to "\n").
    */
-  String getValue([String separator = '\n']) => callArg('getValue', separator);
+  String getValue([String separator]) => callArg('getValue', separator);
 
   /**
    * Set the editor content.
@@ -883,7 +883,7 @@ class Doc extends ProxyHolder {
    * argument can be given to indicate the line separator string to use
    * (defaults to "\n").
    */
-  String getRange(Position from, Position to, [String separator = '\n']) {
+  String getRange(Position from, Position to, [String separator]) {
     return callArgs('getRange', [from.toProxy(), to.toProxy(), separator]);
   }
 

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -876,8 +876,8 @@ class Doc extends ProxyHolder {
    * argument can be given to indicate the line separator string to use
    * (defaults to "\n").
    */
-  String getRange(Position from, Position to) {
-    return callArgs('getRange', [from.toProxy(), to.toProxy()]);
+  String getRange(Position from, Position to, [String separator = '\n']) {
+    return callArgs('getRange', [from.toProxy(), to.toProxy(), separator]);
   }
 
   /**


### PR DESCRIPTION
`Doc.getRange` and `Doc.getValue` accept an optional `separator` argument to specify the string to be used to separate lines.