### PR TITLE
Add MergeView and DiffView to interop with merge addon

### DIFF
--- a/README_.google
+++ b/README_.google
@@ -1,5 +1,5 @@
 URL: http://codemirror.net/
-Version: 5.58.0
+Version: 5.59.0
 License: MIT
 License File: third_party/codemirror/LICENSE
 

--- a/README_.google
+++ b/README_.google
@@ -1,5 +1,5 @@
 URL: http://codemirror.net/
-Version: 5.59.0
+Version: 5.58.0
 License: MIT
 License File: third_party/codemirror/LICENSE
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## 0.5.22
- - update to CodeMirror 5.59.0
  - Add `MergeView` and `DiffView` to interop with the merge addon
 
 ## 0.5.21

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.22
+ - update to CodeMirror 5.59.0
+ - Add `MergeView` and `DiffView` to interop with the merge addon
+
 ## 0.5.21
  - update to CodeMirror 5.58.0
 

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -1230,6 +1230,51 @@ class Token {
   String toString() => string;
 }
 
+/// A wrapper around the MergeView class.
+class MergeView extends ProxyHolder {
+  /// Create a new MergeView in the given element. See
+  /// https://codemirror.net/doc/manual.html#addon_merge for valid options values.
+  MergeView(Element element, Map options) : super(_create(element, options));
+
+  MergeView.fromProxy(JsObject proxy) : super(proxy);
+
+  static JsObject _create(Element element, Map options) {
+    return JsObject(
+        context['CodeMirror']['MergeView'], [element, jsify(options)]);
+  }
+
+  /// The reference to the edit property.
+  CodeMirror get edit => CodeMirror.fromJsObject(jsProxy['edit']);
+
+  /// The reference to the left property.
+  DiffView get left => DiffView.fromJsObject(jsProxy['left']);
+}
+
+/// A wrapper around the DiffView class.
+class DiffView extends ProxyHolder {
+  static final Map<JsObject, DiffView> _instances = {};
+
+  DiffView.fromProxy(JsObject proxy) : super(proxy);
+
+  factory DiffView.fromJsObject(JsObject object) {
+    if (_instances.containsKey(object)) {
+      return _instances[object];
+    } else {
+      return DiffView._fromJsObject(object);
+    }
+  }
+
+  DiffView._fromJsObject(JsObject object) : super(object) {
+    _instances[jsProxy] = this;
+  }
+
+  /// The reference to the edit property.
+  CodeMirror get edit => CodeMirror.fromJsObject(jsProxy['edit']);
+
+  /// The reference to the orig property.
+  CodeMirror get orig => CodeMirror.fromJsObject(jsProxy['orig']);
+}
+
 /// A parent class for objects that can hold references to JavaScript objects.
 /// It has convenience methods for invoking methods on the JavaScript proxy,
 /// a method to add event listeners to the proxy, and a [dispose] method.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: codemirror
-version: 0.5.22+5.59.0
+version: 0.5.22+5.58.0
 description: A Dart wrapper around the CodeMirror text editor.
 homepage: https://github.com/google/codemirror.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: codemirror
-version: 0.5.21+5.58.0
+version: 0.5.22+5.59.0
 description: A Dart wrapper around the CodeMirror text editor.
 homepage: https://github.com/google/codemirror.dart
 

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -25,6 +25,8 @@ void main() {
   group('Doc', createDocTests);
   group('HtmlDoc', createHtmlDocTests);
   group('history', createHistoryTests);
+
+  group('MergeView', createMergeViewTests);
 }
 
 void createSimpleTests() {
@@ -240,6 +242,48 @@ void createHistoryTests() {
     var doc = editor.getDoc();
     doc.setValue('one\ntwo\nthree');
     expect(doc.getHistory(), isNotNull);
+  });
+}
+
+void createMergeViewTests() {
+  MergeView mergeView;
+
+  final someMergeViewOptions = {
+    'value': 'AAAAAA',
+    'origLeft': 'BBBBBB',
+    'showDifferences': true,
+    'revertButtons': false,
+  };
+
+  setUp(() {
+    mergeView = MergeView(editorHost, someMergeViewOptions);
+  });
+
+  test('creates a MergeView class', () {
+    expect(mergeView, isA<MergeView>());
+  });
+
+  test('has correct properties', () {
+    expect(mergeView.edit, isA<CodeMirror>());
+    expect(mergeView.left, isA<DiffView>());
+  });
+
+  group(DiffView, () {
+    DiffView diffView;
+
+    setUp(() {
+      diffView = mergeView.left;
+    });
+
+    test('has correct properties', () {
+      expect(diffView.edit, isA<CodeMirror>());
+      expect(diffView.orig, isA<CodeMirror>());
+    });
+
+    test('has correct values', () {
+      expect(diffView.edit.getDoc().getValue(), equals('AAAAAA'));
+      expect(diffView.orig.getDoc().getValue(), equals('BBBBBB'));
+    });
   });
 }
 

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -25,7 +25,6 @@ void main() {
   group('Doc', createDocTests);
   group('HtmlDoc', createHtmlDocTests);
   group('history', createHistoryTests);
-
   group('MergeView', createMergeViewTests);
 }
 

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -247,16 +247,14 @@ void createHistoryTests() {
 void createMergeViewTests() {
   MergeView mergeView;
 
-  final someMergeViewOptions = {
+  const someMergeViewOptions = {
     'value': 'AAAAAA',
     'origLeft': 'BBBBBB',
     'showDifferences': true,
     'revertButtons': false,
   };
 
-  setUp(() {
-    mergeView = MergeView(editorHost, someMergeViewOptions);
-  });
+  mergeView = MergeView(editorHost, someMergeViewOptions);
 
   test('creates a MergeView class', () {
     expect(mergeView, isA<MergeView>());

--- a/test/all_test.html
+++ b/test/all_test.html
@@ -11,6 +11,8 @@
     <title>Dart CodeMirror Tests</title>
     <link rel="x-dart-test" href="all_test.dart">
     <script src="packages/test/dart.js"></script>
+    <!-- Depency required for merge addon -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/diff_match_patch/20121119/diff_match_patch.js"></script>
     <link href="packages/codemirror/codemirror.css" rel="stylesheet">
   </head>
 

--- a/test/all_test.html
+++ b/test/all_test.html
@@ -11,7 +11,7 @@
     <title>Dart CodeMirror Tests</title>
     <link rel="x-dart-test" href="all_test.dart">
     <script src="packages/test/dart.js"></script>
-    <!-- Depency required for merge addon -->
+    <!-- Required dependency for merge addon -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/diff_match_patch/20121119/diff_match_patch.js"></script>
     <link href="packages/codemirror/codemirror.css" rel="stylesheet">
   </head>

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -76,6 +76,9 @@ String _concatenateModes(Directory dir) {
   files.add(joinFile(dir, ['addon', 'search', 'search.js']));
   files.add(joinFile(dir, ['addon', 'search', 'searchcursor.js']));
 
+  // Add merge addons.
+  files.add(joinFile(dir, ['addon', 'merge', 'merge.js']));
+
   // Required by some modes.
   files.add(joinFile(dir, ['addon', 'mode', 'overlay.js']));
   files.add(joinFile(dir, ['addon', 'mode', 'simple.js']));


### PR DESCRIPTION
This PR adds the classes needed to interop with the [merge addon](https://codemirror.net/doc/manual.html#addon_merge).

* Add the MergeView and DiffView wrapper;
* Bump the codemirror.dart wrapper version;