### PR TITLE
RegisterHintsHelper fix

### DIFF
--- a/lib/hints.dart
+++ b/lib/hints.dart
@@ -53,9 +53,9 @@ class Hints {
     _init();
 
     JsFunction function =
-        new JsFunction.withThis((win, editor, showHints, [options]) {
-      HintResults results = helper(new CodeMirror.fromJsObject(editor),
-          new HintsOptions.fromProxy(options));
+        JsFunction.withThis((win, editor, showHints, [options]) {
+      HintResults results = helper(
+          CodeMirror.fromJsObject(editor), HintsOptions.fromProxy(options));
       return results == null ? null : results.toProxy();
     });
 

--- a/lib/hints.dart
+++ b/lib/hints.dart
@@ -52,9 +52,9 @@ class Hints {
   static void registerHintsHelper(String mode, HintsHelper helper) {
     _init();
 
-    JsFunction function =
+    var function =
         JsFunction.withThis((win, editor, showHints, [options]) {
-      HintResults results = helper(
+      var results = helper(
           CodeMirror.fromJsObject(editor), HintsOptions.fromProxy(options));
       return results == null ? null : results.toProxy();
     });


### PR DESCRIPTION
RegisterHintsHelper method was adding a non-JSObject type as a helper, resulting in an error when getHelper was called.