### PR TITLE
Feat[addons] Add SearchCursor wrapper

### DIFF
--- a/lib/searchcursor.dart
+++ b/lib/searchcursor.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2021, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// A wrapper around the `addon/search/searchcursor.js` addon.
+library codemirror.searchcursor;
+
+import 'dart:js';
+
+import 'src/js_utils.dart';
+import 'codemirror.dart';
+
+class SearchCursor {
+  /// Retrieve the search cursor from the editor instance.
+  static SearchCursorContainer getSearchCursor(CodeMirror editor, String value,
+      {Position? start, Map? options}) {
+    if (options == null) {
+      return SearchCursorContainer._(
+          editor.callArgs('getSearchCursor', [value, start]));
+    } else {
+      return SearchCursorContainer._(
+          editor.callArgs('getSearchCursor', [value, start, jsify(options)]));
+    }
+  }
+}
+
+class SearchCursorContainer extends ProxyHolder {
+  SearchCursorContainer._(JsObject? jsProxy) : super(jsProxy);
+
+  bool get atOccurrence => jsProxy!['atOccurrence'];
+  Doc get doc => jsProxy!['doc'];
+  Position get pos => Position.fromProxy(jsProxy!['pos']);
+
+  /// Search forward from the current position
+  bool findNext() => call('findNext');
+
+  /// Search backward from the current position
+  bool findPrevious() => call('findPrevious');
+  Position from() => Position.fromProxy(call('from'));
+  Position to() => Position.fromProxy(call('to'));
+  String replace(String text, String? origin) =>
+      callArgs('replace', [text, origin]);
+}

--- a/lib/searchcursor.dart
+++ b/lib/searchcursor.dart
@@ -28,7 +28,7 @@ class SearchCursorContainer extends ProxyHolder {
   SearchCursorContainer._(JsObject? jsProxy) : super(jsProxy);
 
   bool get atOccurrence => jsProxy!['atOccurrence'];
-  Doc get doc => jsProxy!['doc'];
+  Doc get doc => Doc.fromProxy(jsProxy!['doc']);
   Position get pos => Position.fromProxy(jsProxy!['pos']);
 
   /// Search forward from the current position
@@ -38,6 +38,11 @@ class SearchCursorContainer extends ProxyHolder {
   bool findPrevious() => call('findPrevious');
   Position from() => Position.fromProxy(call('from'));
   Position to() => Position.fromProxy(call('to'));
-  String replace(String text, String? origin) =>
-      callArgs('replace', [text, origin]);
+  String replace(String text, {dynamic origin}) {
+    if (origin == null) {
+      return callArg('replace', text);
+    } else {
+      return callArgs('replace', [text, origin]);
+    }
+  }
 }

--- a/test/searchcursor_test.dart
+++ b/test/searchcursor_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library codemirror.tests;
+
+import 'dart:html';
+
+import 'package:codemirror/codemirror.dart';
+import 'package:test/test.dart';
+import 'package:codemirror/searchcursor.dart';
+
+void main() {
+  group('searchCursor', createSearchCursorTests);
+}
+
+void createSearchCursorTests() {
+  late CodeMirror editor;
+
+  setUp(() {
+    editor = CodeMirror.fromTextArea(
+        querySelector('#textContainer') as TextAreaElement?);
+  });
+
+  tearDown(() {
+    editor.dispose();
+  });
+
+  test('getSearchCursor', () {
+    var cursor = SearchCursor.getSearchCursor(editor, 'Lorem');
+    print(cursor.pos);
+    expect(cursor, isNotNull);
+    expect(cursor, isA<SearchCursorContainer>());
+  });
+
+  test('findPrevious / findNext', () {
+    var cursor = SearchCursor.getSearchCursor(editor, 'ipsum');
+    var hasNext = cursor.findNext();
+    expect(hasNext, isTrue);
+
+    cursor.findNext();
+
+    var hasPrev = cursor.findPrevious();
+    expect(hasPrev, isTrue);
+  });
+
+  test('from / to', () {
+    var cursor = SearchCursor.getSearchCursor(editor, 'Pellentesque');
+    cursor.findNext();
+
+    var from = cursor.from();
+    var to = cursor.to();
+    expect(from, isNotNull);
+    expect(to, isNotNull);
+  });
+
+  test('replace', () {
+    // TODO(ayshiff) fix failing test
+    // var notFoundCursor = SearchCursor.getSearchCursor(editor, 'auctor_replaced');
+    // expect(notFoundCursor.findNext(), isFalse);
+    //
+    // var cursor = SearchCursor.getSearchCursor(editor, 'auctor');
+    // cursor.findNext();
+    //
+    // cursor.replace('auctor_replaced');
+    // var foundCursor = SearchCursor.getSearchCursor(editor, 'auctor_replaced');
+    // expect(foundCursor.findNext(), isTrue);
+  });
+
+  test('atOccurrence', () {
+    var cursor = SearchCursor.getSearchCursor(editor, 'dolor');
+    cursor.findNext();
+    expect(cursor.atOccurrence, isTrue);
+  });
+
+  test('doc', () {
+    var cursor = SearchCursor.getSearchCursor(editor, 'sapien');
+    expect(cursor.doc, isA<Doc>());
+  });
+
+  test('pos', () {
+    var cursor = SearchCursor.getSearchCursor(editor, 'ipsum');
+    expect(cursor.pos, isA<Position>());
+  });
+}

--- a/test/searchcursor_test.html
+++ b/test/searchcursor_test.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<!-- Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+     All rights reserved. Use of this source code is governed by a BSD-style
+     license that can be found in the LICENSE file. -->
+
+<html>
+  <head>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dart CodeMirror Tests</title>
+    <link rel="x-dart-test" href="searchcursor_test.dart">
+    <script src="packages/test/dart.js"></script>
+    <link href="packages/codemirror/codemirror.css" rel="stylesheet">
+  </head>
+
+  <body>
+    <script src="packages/codemirror/codemirror.js"></script>
+
+    <textarea id="textContainer">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Nulla tempor eget sapien at tincidunt. Morbi congue neque
+      lacus, imperdiet auctor tortor pulvinar vel. Pellentesque
+      habitant morbi tristique senectus et netus et malesuada
+      fames ac turpis egestas. Pellentesque auctor lorem nec sem
+      ultricies sagittis. Donec congue aliquet orci dictum
+      convallis. Pellentesque posuere, ante in volutpat ultrices,
+      ipsum nisl commodo neque, quis commodo dui ex sed purus.
+      Sed vitae ex quis velit porttitor consequat.
+    </textarea>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a wrapper around the `addon/search/searchcursor.js` addon.
This wrapper will be used for https://github.com/dart-lang/dart-pad/issues/1866