### PR TITLE
Update included CM scripts and add capability to generate minified version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.7.3+5.65.2
+- `build` task now creates all required output directories before proceeding with build.
+- Added `build_minified` task which minifies all codemirror source files using the google closure compilers SIMPLE_OPTIMIZATIONS before running `build` task.  The final minified output is functionaly equivalent to the non-minified version, only smaller.  Node is required for `build_minified` as npm is used to install the google closure compiler, et al.
+- Added `clean_node` and `clean_minified` tasks to remove all artifacts from the `build_minified` task
+- Renamed `clean` to `clean_lib` and fixed it so that it truely removed all artifacts from the `build` task
+- Made `clean` dependent on `clean_lib`, `clean_node` and `clean_minified` so that the clean task will run all these in turn and clean all possible artifacts from either the `build` or `build_minified` tasks
+- By default now create a `css/codemirror.css` file which has all of the codemirror css files dart-pad uses contenated together.  `--noextras` option can be used to create same codemirror.css as previous version (preventing contenation)
+- By default output `codemirror.js` file now includes all additional codemirror addon files which dart-pad now uses. `--noextras` option can be used to create the same codemirror.js file as previous version  
+- By default `codemirror.js` and `css/codemirror.css` output files both receive a summary header comment which details all concontenated codemirror source files they include.  `--noheader` option can be used to prevent the summary header and produce the same output as previous version
+
 ## 0.7.2+5.65.2
 - Update to CodeMirror 5.65.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: codemirror
-version: 0.7.2+5.65.2
+version: 0.7.3+5.65.2
 description: A Dart wrapper around the CodeMirror text editor.
 homepage: https://github.com/google/codemirror.dart
 

--- a/third_party/gulpfile.js
+++ b/third_party/gulpfile.js
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * The MIT License
+ *
+ * Copyright (c) 2016 Michael Zhou
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/**
+ * @fileoverview Minification process for CodeMirror.
+ * @author zhoumotongxue008@gmail.com (Michael Zhou)
+ * 
+ * This file was orginally part of https://github.com/Dominator008/CodeMirror-minified
+ * and has been repurposed to minify the codemirror source for codemirror.dart
+ */
+
+'use strict';
+
+const {series, parallel, src, dest} = require('gulp');
+const flatmap = require('gulp-flatmap');
+const closureCompiler = require('google-closure-compiler').gulp();
+const cleanCss = require('gulp-clean-css');
+
+const CM_ROOT = 'codemirror/';
+const CM_MINIFIED_ROOT = 'codemirror_minified/';
+
+function runFlatMap() {
+  return flatmap((stream, file) => {
+    const pathAtCmRoot = file.relative.replace(CM_ROOT, '');
+    // Travis kills a build if no log output for 10 minutes
+    console.log('Minifying ' + pathAtCmRoot);
+    return stream.pipe(closureCompiler({
+      compilation_level: 'SIMPLE',
+      language_in: 'STABLE',
+      language_out: 'ECMASCRIPT5_STRICT',
+      js_output_file: pathAtCmRoot,
+      warning_level: 'QUIET'
+    }));
+  });
+}
+
+function minifyMainJs() {
+  return src(
+             [
+               CM_ROOT + 'addon/**/*.js',
+               CM_ROOT + 'keymap/**/*.js',
+               CM_ROOT + 'lib/**/*.js',
+             ],
+             {base: '.'})
+      .pipe(runFlatMap())
+      .pipe(dest(CM_MINIFIED_ROOT));
+}
+
+function minifyModesJs() {
+  return src([CM_ROOT + 'mode/**/*.js', '!' + CM_ROOT + 'mode/**/*test.js'],
+             {base: '.'})
+      .pipe(runFlatMap())
+      .pipe(dest(CM_MINIFIED_ROOT));
+}
+
+function minifyCss() {
+  return src(
+             [
+               CM_ROOT + 'addon/**/*.css', CM_ROOT + 'lib/**/*.css',
+               CM_ROOT + 'mode/**/*.css', CM_ROOT + 'theme/**/*.css'
+             ],
+             {base: CM_ROOT})
+      .pipe(cleanCss())
+      .pipe(dest(CM_MINIFIED_ROOT));
+}
+
+function copyTextFiles() {
+  return src([CM_ROOT + 'AUTHORS', CM_ROOT + 'CHANGELOG.md'], {base: CM_ROOT})
+      .pipe(dest(CM_MINIFIED_ROOT));
+}
+
+exports.minify = parallel(minifyMainJs, minifyModesJs, minifyCss);
+exports.default = series(copyTextFiles, exports.minify);

--- a/third_party/gulpfile.js
+++ b/third_party/gulpfile.js
@@ -37,13 +37,15 @@ const {series, parallel, src, dest} = require('gulp');
 const flatmap = require('gulp-flatmap');
 const closureCompiler = require('google-closure-compiler').gulp();
 const cleanCss = require('gulp-clean-css');
+const path = require('path');
 
 const CM_ROOT = 'codemirror/';
+const CM_ROOT_PLATFORM_SEP = 'codemirror'+path.sep;
 const CM_MINIFIED_ROOT = 'codemirror_minified/';
 
 function runFlatMap() {
   return flatmap((stream, file) => {
-    const pathAtCmRoot = file.relative.replace(CM_ROOT, '');
+    const pathAtCmRoot = file.relative.replace(CM_ROOT_PLATFORM_SEP, '');
     // Travis kills a build if no log output for 10 minutes
     console.log('Minifying ' + pathAtCmRoot);
     return stream.pipe(closureCompiler({

--- a/third_party/package.json
+++ b/third_party/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "codemirror-dart-minifier",
+  "version": "1.0.0",
+  "main": "gulpfile.js",
+  "description": "Minifies CodeMirror distribution",
+  "license": "MIT",
+  "files": [
+    "package.json",
+    "gulpfile.js"
+  ],
+  "devDependencies": {
+    "google-closure-compiler": "^20220301.0.0",
+    "gulp": "^4.0.2",
+    "gulp-clean-css": "^4.3.0",
+    "gulp-flatmap": "^1.0.2"
+  },
+  "jspm": {
+    "directories": {},
+    "dependencies": {},
+    "devDependencies": {}
+  }
+}

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -33,7 +33,7 @@ void build_minified() {
   build();
 }
 
-@Task('Copy the codemirror files from third_party/ into lib/\noptional args:\n  --legacyaddons : include no extra addons\n  --noheader : do not include summary filelist in codemirror.js header')
+@Task('Copy the codemirror files from third_party/ into lib/\noptional args:\n  --extras : include extra addons\n  --noheader : do not include summary filelist in codemirror.js header')
 void build() {
   // Copy codemirror.js.
   var jsSource = _concatenateModesAndOtherDependencies(srcDir);
@@ -85,7 +85,7 @@ void clean_node() {
 
 String _concatenateModesAndOtherDependencies(Directory dir) {
   TaskArgs args = context.invocation.arguments;
-  bool legacyAddons = args.getFlag('legacyaddons');
+  bool extraAddons = args.getFlag('extras');
   bool noHeader = args.getFlag('noheader');
   var files = <File>[];
 
@@ -115,7 +115,7 @@ String _concatenateModesAndOtherDependencies(Directory dir) {
   files.add(joinFile(dir, ['addon', 'search', 'search.js']));
   files.add(joinFile(dir, ['addon', 'search', 'searchcursor.js']));
 
-  if (!legacyAddons) {
+  if (extraAddons) {
     // used on all dart-pads
     files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -71,8 +71,13 @@ void test() {
   run('pub', arguments: ['run', 'test:test', '--platform=chrome']);
 }
 
-@Task('Delete all generated artifacts')
+@Task('Delete all generated and minifier artifacts')
+@Depends(clean_lib,clean_minified,clean_node)
 void clean() {
+}
+
+@Task('Delete all generated artifacts placed in lib/')
+void clean_lib() {
   delete(joinFile(destDir, ['codemirror.js']));
   delete(joinFile(destDir, ['css', 'codemirror.css']));
   delete(joinDir(destDir, ['addon']));

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -157,12 +157,15 @@ String _concatenateModesAndOtherDependencies(Directory dir) {
   files.add(joinFile(dir, ['addon', 'dialog', 'dialog.js']));
   files.add(joinFile(dir, ['keymap', 'vim.js']));
 
-//  var modeFiles = joinDir(dir, ['mode'])
-//    .listSync()
-//    .where((dir) => dir is Directory)
-//    .map((dir) => joinFile(dir, ['${fileName(dir)}.js']))
-//    .where((f) => f.existsSync());
-//  files.addAll(modeFiles);
+  //  var modeFiles = joinDir(dir, ['mode'])
+  //    .listSync()
+  //    .where((dir) => dir is Directory)
+  //    .map((dir) => joinFile(dir, ['${fileName(dir)}.js']))
+  //    .where((f) => f.existsSync());
+  //  files.addAll(modeFiles);
+
+  // make a header for the file with a list of every file we combined
+  //   so this info is available in one convenient place
   int count = 0;
   String topHeaderFileList = files.map((File file) {
     String filenameCommentForHeader;
@@ -170,7 +173,7 @@ String _concatenateModesAndOtherDependencies(Directory dir) {
       // codemirror file
       filenameCommentForHeader = '// ${fileName(file)}';
     } else {
-      // addons
+      // for modes,addons,keymaps include path and indent
       List<String> fileparts = file.path.split('/');
       int len = fileparts.length;
       filenameCommentForHeader = '//    ' +

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -15,7 +15,7 @@ final Directory destDir = Directory('lib');
 Future main(List<String> args) => grind(args);
 
 @Task(
-    'Minify the codemirror files, and then proceed with "build" using minified codemirror\noptional args (can include "build" arguments also):\n --verbose shows intermediate node/closure output')
+    'Minify the codemirror files, and then proceed with "build" using minified codemirror\n      optional args (can include "build" arguments also):\n        --verbose  : shows intermediate node/closure output')
 @Depends(clean_minified)
 void build_minified() {
   TaskArgs args = context.invocation.arguments;
@@ -34,7 +34,7 @@ void build_minified() {
 }
 
 @Task(
-    'Copy the codemirror files from third_party/ into lib/\noptional args:\n  --noextras : do not include extra addons or css\n  --noheader : do not include summary filelist in codemirror.js header')
+    'Copy the codemirror files from third_party/ into lib/\n      optional args:\n        --noextras : do not include extra addons or css\n        --noheader : do not include summary filelist in codemirror.js header')
 void build() {
   TaskArgs args = context.invocation.arguments;
   bool noExtraCss = args.getFlag('noextras');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -6,15 +6,37 @@ import 'dart:io';
 
 import 'package:grinder/grinder.dart';
 
-final Directory srcDir = Directory('third_party/codemirror');
+final String cm_minified_dirname = 'codemirror_minified';
+final Directory srcMinifiedDir =
+    joinDir(Directory('third_party'), [cm_minified_dirname]);
+Directory srcDir = Directory('third_party/codemirror');
 final Directory destDir = Directory('lib');
 
 Future main(List<String> args) => grind(args);
 
+@Task(
+    'Minify the codemirror files, and then proceed with "build" using minified codemirror\n--verbose shows intermediate output')
+@Depends(clean_minified)
+void build_minified() {
+  TaskArgs args = context.invocation.arguments;
+  bool verbose = args.getFlag('verbose');
+  RunOptions runOpts = RunOptions(
+      workingDirectory: 'third_party', includeParentEnvironment: true);
+  // make sure google closure compiler is there
+  run('npm', arguments: ['install'], quiet: !verbose, runOptions: runOpts);
+
+  // run the gulpfile.js and minify codemirror into codemirror_minified
+  run('gulp', quiet: !verbose, runOptions: runOpts);
+
+  // OK we can go ahead and build like normal, but using the minified source
+  srcDir = srcMinifiedDir;
+  build();
+}
+
 @Task('Copy the codemirror files from third_party/ into lib/')
 void build() {
   // Copy codemirror.js.
-  var jsSource = _concatenateModes(srcDir);
+  var jsSource = _concatenateModesAndOtherDependencies(srcDir);
   joinFile(destDir, ['codemirror.js']).writeAsStringSync(jsSource);
   //copy(joinFile(srcDir, ['lib', 'codemirror.js']), destDir);
 
@@ -43,10 +65,28 @@ void test() {
 void clean() {
   delete(joinFile(destDir, ['codemirror.js']));
   delete(joinFile(destDir, ['css', 'codemirror.css']));
-  delete(joinFile(destDir, ['theme']));
+  delete(joinDir(destDir, ['addon']));
+  delete(joinDir(destDir, ['keymap']));
+  delete(joinDir(destDir, ['mode']));
+  delete(joinDir(destDir, ['theme']));
 }
 
-String _concatenateModes(Directory dir) {
+@Task('Delete all generated minified codemirror')
+void clean_minified() {
+  delete(srcMinifiedDir);
+}
+
+@Task('Delete all node modules used by minifier,build_minified will reinstall')
+void clean_node() {
+  final Directory thirdPartyDir = Directory('third_party');
+  delete(joinDir(thirdPartyDir, ['node_modules']));
+  delete(joinFile(thirdPartyDir, ['package-lock.json']));
+}
+
+String _concatenateModesAndOtherDependencies(Directory dir) {
+  TaskArgs args = context.invocation.arguments;
+  bool legacyAddons = args.getFlag('legacyaddons');
+
   var files = <File>[];
 
   // Read lib/codemirror.js.
@@ -70,15 +110,29 @@ String _concatenateModes(Directory dir) {
 
   // Add an API to add a panel above or below the editor.
   files.add(joinFile(dir, ['addon', 'display', 'panel.js']));
-  files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
 
   // Add search addons.
-  files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
   files.add(joinFile(dir, ['addon', 'search', 'search.js']));
   files.add(joinFile(dir, ['addon', 'search', 'searchcursor.js']));
-  files.add(joinFile(dir, ['addon', 'scroll', 'annotatescrollbar.js']));
-  files.add(joinFile(dir, ['addon', 'search', 'matchesonscrollbar.js']));
-  files.add(joinFile(dir, ['addon', 'search', 'match-highlighter.js']));
+
+  if (!legacyAddons) {
+    // used on all dart-pads
+    files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
+
+    // search dialog
+    files.add(joinFile(dir, ['addon', 'scroll', 'annotatescrollbar.js']));
+    files.add(joinFile(dir, ['addon', 'search', 'matchesonscrollbar.js']));
+    files.add(joinFile(dir, ['addon', 'search', 'match-highlighter.js']));
+    // code folding
+    files.add(joinFile(dir, ['addon', 'fold', 'foldcode.js']));
+    files.add(joinFile(dir, ['addon', 'fold', 'foldgutter.js']));
+    files.add(joinFile(dir, ['addon', 'fold', 'brace-fold.js']));
+    files.add(joinFile(dir, ['addon', 'fold', 'xml-fold.js']));
+    files.add(joinFile(dir, ['addon', 'fold', 'indent-fold.js']));
+    files.add(joinFile(dir, ['addon', 'fold', 'comment-fold.js']));
+    // html tag matching
+    files.add(joinFile(dir, ['addon', 'edit', 'matchtags.js']));
+  }
 
   // Required by some modes.
   files.add(joinFile(dir, ['addon', 'mode', 'overlay.js']));
@@ -103,16 +157,35 @@ String _concatenateModes(Directory dir) {
   files.add(joinFile(dir, ['addon', 'dialog', 'dialog.js']));
   files.add(joinFile(dir, ['keymap', 'vim.js']));
 
-
 //  var modeFiles = joinDir(dir, ['mode'])
 //    .listSync()
 //    .where((dir) => dir is Directory)
 //    .map((dir) => joinFile(dir, ['${fileName(dir)}.js']))
 //    .where((f) => f.existsSync());
 //  files.addAll(modeFiles);
-
-  return files.map((File file) {
-    var header = '// ${fileName(file)}\n\n';
-    return header + file.readAsStringSync().trim() + '\n';
+  int count = 0;
+  String topHeaderFileList = files.map((File file) {
+    String filenameCommentForHeader;
+    if (count++ == 0) {
+      // codemirror file
+      filenameCommentForHeader = '// ${fileName(file)}';
+    } else {
+      // addons
+      List<String> fileparts = file.path.split('/');
+      int len = fileparts.length;
+      filenameCommentForHeader = '//    ' +
+          (len >= 3 && (fileparts[len - 3] != cm_minified_dirname)
+              ? fileparts[len - 3] + '/'
+              : '') +
+          (len >= 2 ? fileparts[len - 2] + '/' : '') +
+          fileparts[len - 1];
+    }
+    return filenameCommentForHeader;
   }).join('\n');
+
+  return '$topHeaderFileList\n\n' +
+      files.map((File file) {
+        var header = '// ${fileName(file)}\n\n';
+        return header + file.readAsStringSync().trim() + '\n';
+      }).join('\n');
 }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -50,7 +50,7 @@ void build() {
         joinFile(srcDir, ['lib', 'codemirror.css']), joinDir(destDir, ['css']));
   } else {
     var cssFiles = _concatenateCSSFileDependencies(srcDir);
-    joinFile(destDir, ['css', 'codemirror.css']).writeAsStringSync(cssFiles);
+    joinFile( joinDir(destDir, ['css']), ['codemirror.css']).writeAsStringSync(cssFiles);
   }
 
   // Copy the addons.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -35,7 +35,7 @@ void build_minified() {
 
 @Task(
     'Copy the codemirror files from third_party/ into lib/\n      optional args:\n        --noextras : do not include extra addons or css\n        --noheader : do not include summary filelist in codemirror.js header')
-void build() {
+void build() async {
   TaskArgs args = context.invocation.arguments;
   bool noExtraCss = args.getFlag('noextras');
 
@@ -44,13 +44,20 @@ void build() {
   joinFile(destDir, ['codemirror.js']).writeAsStringSync(jsSource);
   //copy(joinFile(srcDir, ['lib', 'codemirror.js']), destDir);
 
+  // ensure output directories exist before continuing
+  await joinDir(destDir, ['css']).create(recursive: true);
+  await joinDir(destDir, ['addon']).create(recursive: true);
+  await joinDir(destDir, ['keymap']).create(recursive: true);
+  await joinDir(destDir, ['mode']).create(recursive: true);
+  await joinDir(destDir, ['theme']).create(recursive: true);
+
   if (noExtraCss) {
     // Copy codemirror.css.
     copy(
         joinFile(srcDir, ['lib', 'codemirror.css']), joinDir(destDir, ['css']));
   } else {
     var cssFiles = _concatenateCSSFileDependencies(srcDir);
-    joinFile( joinDir(destDir, ['css']), ['codemirror.css']).writeAsStringSync(cssFiles);
+    joinFile(destDir, ['css', 'codemirror.css']).writeAsStringSync(cssFiles);
   }
 
   // Copy the addons.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -72,9 +72,8 @@ void test() {
 }
 
 @Task('Delete all generated and minifier artifacts')
-@Depends(clean_lib,clean_minified,clean_node)
-void clean() {
-}
+@Depends(clean_lib, clean_minified, clean_node)
+void clean() {}
 
 @Task('Delete all generated artifacts placed in lib/')
 void clean_lib() {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -15,7 +15,7 @@ final Directory destDir = Directory('lib');
 Future main(List<String> args) => grind(args);
 
 @Task(
-    'Minify the codemirror files, and then proceed with "build" using minified codemirror\noptional args (can include "build" arguments also):\n --verbose shows intermediate output')
+    'Minify the codemirror files, and then proceed with "build" using minified codemirror\noptional args (can include "build" arguments also):\n --verbose shows intermediate node/closure output')
 @Depends(clean_minified)
 void build_minified() {
   TaskArgs args = context.invocation.arguments;
@@ -34,17 +34,17 @@ void build_minified() {
 }
 
 @Task(
-    'Copy the codemirror files from third_party/ into lib/\noptional args:\n  --extras : include extra addons\n  --noheader : do not include summary filelist in codemirror.js header')
+    'Copy the codemirror files from third_party/ into lib/\noptional args:\n  --noextras : do not include extra addons or css\n  --noheader : do not include summary filelist in codemirror.js header')
 void build() {
   TaskArgs args = context.invocation.arguments;
-  bool joinCss = args.getFlag('css');
+  bool noExtraCss = args.getFlag('noextras');
 
   // Copy codemirror.js.
   var jsSource = _concatenateModesAndOtherDependencies(srcDir);
   joinFile(destDir, ['codemirror.js']).writeAsStringSync(jsSource);
   //copy(joinFile(srcDir, ['lib', 'codemirror.js']), destDir);
 
-  if (!joinCss) {
+  if (noExtraCss) {
     // Copy codemirror.css.
     copy(
         joinFile(srcDir, ['lib', 'codemirror.css']), joinDir(destDir, ['css']));
@@ -95,7 +95,7 @@ void clean_node() {
 
 String _concatenateModesAndOtherDependencies(Directory dir) {
   TaskArgs args = context.invocation.arguments;
-  bool extraAddons = args.getFlag('extras');
+  bool noExtraAddons = args.getFlag('noextras');
   bool noHeader = args.getFlag('noheader');
   var files = <File>[];
 
@@ -125,7 +125,7 @@ String _concatenateModesAndOtherDependencies(Directory dir) {
   files.add(joinFile(dir, ['addon', 'search', 'search.js']));
   files.add(joinFile(dir, ['addon', 'search', 'searchcursor.js']));
 
-  if (extraAddons) {
+  if (!noExtraAddons) {
     // used on all dart-pads
     files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -70,10 +70,15 @@ String _concatenateModes(Directory dir) {
 
   // Add an API to add a panel above or below the editor.
   files.add(joinFile(dir, ['addon', 'display', 'panel.js']));
+  files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
 
   // Add search addons.
+  files.add(joinFile(dir, ['addon', 'scroll', 'simplescrollbars.js']));
   files.add(joinFile(dir, ['addon', 'search', 'search.js']));
   files.add(joinFile(dir, ['addon', 'search', 'searchcursor.js']));
+  files.add(joinFile(dir, ['addon', 'scroll', 'annotatescrollbar.js']));
+  files.add(joinFile(dir, ['addon', 'search', 'matchesonscrollbar.js']));
+  files.add(joinFile(dir, ['addon', 'search', 'match-highlighter.js']));
 
   // Required by some modes.
   files.add(joinFile(dir, ['addon', 'mode', 'overlay.js']));
@@ -93,6 +98,11 @@ String _concatenateModes(Directory dir) {
   files.add(joinFile(dir, ['mode', 'shell', 'shell.js']));
   files.add(joinFile(dir, ['mode', 'xml', 'xml.js']));
   files.add(joinFile(dir, ['mode', 'yaml', 'yaml.js']));
+
+  // Read things we need for vim keymap
+  files.add(joinFile(dir, ['addon', 'dialog', 'dialog.js']));
+  files.add(joinFile(dir, ['keymap', 'vim.js']));
+
 
 //  var modeFiles = joinDir(dir, ['mode'])
 //    .listSync()

--- a/updating_codemirror.md
+++ b/updating_codemirror.md
@@ -5,7 +5,7 @@ CodeMirror that this package uses. The first revolve around updating
 the CodeMirror dependencies from Bower, and the second around publishing
 the updated [pub](https://pub.dev) package.
 
-## Updating CodeMirror 
+## Updating CodeMirror
 
 - Download the latest zip ball from [codemirror.net/codemirror.zip](https://codemirror.net/codemirror.zip)
 - Replace the contents of `third_party/codemirror` with the content of the above download


### PR DESCRIPTION
This PR primarily accomplishes several things.
a) it updates the list of commonly included codemirror addon scripts for the concatenated output codemirror.js
b) creates a concatenated codemirror.css output as well
c) adds the ability to generate a google closure compiler optimized version of the all of the codemirror files.
(the safe/conservative SIMPLE_OPTIMIZATIONS level is used, and codemirror is commonly optimized at this level and works perfectly)
d) a summary header is added to the output codemirror.js and codemirror.css files which details all included/concatenated files. this is useful in determining which files have been included without having to look at the grind file. (it was possible to search the file before for a header comment for each file; but that was seemed non obvious and clumsy)


For now `grind build` continues to produce a non-minified version and `grind build_minified` produces the minified version.  There might be  an argument for making `build` produce the minified version by default and having something like `build_debug` for producing the non-minified version.

`grind build --noextras  --noheader` produces output that is identical to that generated before this PR.

a) and b) will allow the dart-pad html files to have their codemirror included scripts and css files reduced to just:
```
<link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
<script src="packages/codemirror/codemirror.js" defer></script>
```
(more concise and readable as well as being a several times reduction in required host connections)

The advantages that c) can bring are reduction to startup time on dart-pad pages and (IMHO) noticeably faster responsiveness of codemirror in general.

```
            Codemirror sized unprocessed vs minified
      (including gzip sizes as the server sends them compressed)
	  
                         |             | unprocessed  |             |  minified
                         | unprocessed |   gzip'ed    |  minified   |  gzip'ed 
 codemirror (--noextras) |    728131   |    183106    |    355609   |   116741
 codemirror              |   1005985   |    244593    |    470496   |   150328

```

Many (most?) sites that use codemirror already use the google closure optimized version (codepen/jsfiddle/svelte/...)

All tasks and options included in this PR were manually tested on macosx, linux and windows.
Automated `grind test` passed on macosx, on linux and windows errors were produced that did not seem to be related to any changes made in this PR.
