### PR TITLE
Make parameters of `setSize` and `scrollTo` nullable as described in …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.7+5.65.5
+ - Fixed a bug of the parameters of `setSize` and `scrollTo` functions are not nullable.
+
 ## 0.7.6+5.65.5
  - Update to CodeMirror 5.65.5
 

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -498,11 +498,11 @@ class CodeMirror extends ProxyHolder {
   /// rules). [width] and [height] can be either numbers (interpreted as pixels)
   /// or CSS units ("100%", for example). You can pass `null` for either of them
   /// to indicate that that dimension should not be changed.
-  void setSize(num width, num height) => callArgs('setSize', [width, height]);
+  void setSize(num? width, num? height) => callArgs('setSize', [width, height]);
 
   /// Scroll the editor to a given (pixel) position. Both arguments may be left
   /// as null or undefined to have no effect.
-  void scrollTo(num x, num y) => callArgs('scrollTo', [x, y]);
+  void scrollTo(num? x, num? y) => callArgs('scrollTo', [x, y]);
 
   /// Get a [ScrollInfo] object that represents the current scroll position, the
   /// size of the scrollable area, and the size of the visible area (minus

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: codemirror
-version: 0.7.6+5.65.5
+version: 0.7.7+5.65.5
 description: A Dart wrapper around the CodeMirror text editor.
 homepage: https://github.com/google/codemirror.dart
 


### PR DESCRIPTION
…dartdoc.

This looks like an oversight when Dart null safety migration is done for these two methods. The parameters should be made nullable since `null` means having no effect as described in the dartdoc.