### PR TITLE
Add setSizeInCssUnits method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.7.11+5.65.13
+ - add setSizeInCssUnits(String?, String?) to the editor
 
 ## 0.7.10+5.65.13
  - Update to CodeMirror 5.65.13

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -501,10 +501,11 @@ class CodeMirror extends ProxyHolder {
   void setSize(num? width, num? height) => callArgs('setSize', [width, height]);
 
   /// Programmatically set the size of the editor (overriding the applicable CSS
-  /// rules). [width] and [height] should be CSS units ("100%", for example). 
+  /// rules). [width] and [height] should be CSS units ("100%", for example).
   /// You can pass `null` for either of them
   /// to indicate that that dimension should not be changed.
-  void setSizeInCssUnits(String? width, String? height) => callArgs('setSize', [width, height]);
+  void setSizeInCssUnits(String? width, String? height) =>
+      callArgs('setSize', [width, height]);
 
   /// Scroll the editor to a given (pixel) position. Both arguments may be left
   /// as null or undefined to have no effect.

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -495,10 +495,16 @@ class CodeMirror extends ProxyHolder {
   String? getTokenTypeAt(Position pos) => callArg('getTokenTypeAt', pos);
 
   /// Programmatically set the size of the editor (overriding the applicable CSS
-  /// rules). [width] and [height] can be either numbers (interpreted as pixels)
-  /// or CSS units ("100%", for example). You can pass `null` for either of them
+  /// rules). [width] and [height] are numbers (interpreted as pixels).
+  /// You can pass `null` for either of them
   /// to indicate that that dimension should not be changed.
   void setSize(num? width, num? height) => callArgs('setSize', [width, height]);
+
+  /// Programmatically set the size of the editor (overriding the applicable CSS
+  /// rules). [width] and [height] should be CSS units ("100%", for example). 
+  /// You can pass `null` for either of them
+  /// to indicate that that dimension should not be changed.
+  void setSizeInCssUnits(String? width, String? height) => callArgs('setSize', [width, height]);
 
   /// Scroll the editor to a given (pixel) position. Both arguments may be left
   /// as null or undefined to have no effect.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: codemirror
-version: 0.7.10+5.65.13
+version: 0.7.11+5.65.13
 description: A Dart wrapper around the CodeMirror text editor.
 repository: https://github.com/google/codemirror.dart
 


### PR DESCRIPTION
Back in 0.4.7 (before the null safety migration) the parameters to setSize were untyped and thus implicitly dynamic
https://github.com/google/codemirror.dart/blob/0.4.7%2B5.41.0/lib/codemirror.dart#L567-L572

According to the dartdoc you could pass in either a number (pixels) or a string (css units). At some point the signature was changed to setSize(num?, num?) and now it appears to not be possible to set the size to a CSS unit. 

In order to preserve the setSize method typing and not be a breaking change, I've added a new method that still calls the original JS setSize method by enforces String arg types. Ive named it setSizeInCssUnits for clarity. I've also updated the doc string for the original setSize method, added a changelog entry and upped the version in the pubspec.yaml.

attn: @domesticmouse 
