### PR TITLE
Migrate dart:html to package:web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.12+5.65.13
+ - Migrate dart:html to package:web/web.dart
+
 ## 0.7.11+5.65.13
  - add setSizeInCssUnits(String?, String?) to the editor
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ final options = <String, String>{
 };
 
 final editor = CodeMirror.fromElement(
-    querySelector('#textContainer')!, options: options);
+    document.querySelector('#textContainer')!, options: options);
 editor.doc.setValue('foo.bar(1, 2, 3);');
 ```
 

--- a/example/simple.dart
+++ b/example/simple.dart
@@ -26,7 +26,8 @@ void main() {
       document.querySelector('#textContainer') as HTMLTextAreaElement?,
       options: options);
 
-  document.querySelector('#version')!.text = 'CodeMirror version ${CodeMirror.version}';
+  document.querySelector('#version')!.text =
+      'CodeMirror version ${CodeMirror.version}';
 
   Hints.registerHintsHelper('dart', _dartCompleter);
   Hints.registerHintsHelperAsync('dart', _dartCompleterAsync);
@@ -42,7 +43,9 @@ void main() {
     }
   }
   themeSelect.onChange.listen((e) {
-    var themeName = (themeSelect.options.item(themeSelect.selectedIndex) as HTMLOptionElement).value;
+    var themeName = (themeSelect.options.item(themeSelect.selectedIndex)
+            as HTMLOptionElement)
+        .value;
     editor.setTheme(themeName);
   });
 
@@ -57,12 +60,15 @@ void main() {
     }
   }
   modeSelect.onChange.listen((e) {
-    var modeName = (modeSelect.options.item(themeSelect.selectedIndex) as HTMLOptionElement).value;
+    var modeName = (modeSelect.options.item(themeSelect.selectedIndex)
+            as HTMLOptionElement)
+        .value;
     editor.setMode(modeName);
   });
 
   // Show line numbers.
-  final lineNumbers = document.querySelector('#lineNumbers') as HTMLInputElement;
+  final lineNumbers =
+      document.querySelector('#lineNumbers') as HTMLInputElement;
   lineNumbers.onChange.listen((e) {
     editor.setLineNumbers(lineNumbers.checked);
   });

--- a/example/simple.dart
+++ b/example/simple.dart
@@ -4,7 +4,7 @@
 
 library example.simple;
 
-import 'dart:html';
+import 'package:web/web.dart';
 
 import 'package:codemirror/codemirror.dart';
 import 'package:codemirror/hints.dart';
@@ -23,48 +23,52 @@ void main() {
   };
 
   var editor = CodeMirror.fromTextArea(
-      querySelector('#textContainer') as TextAreaElement?,
+      document.querySelector('#textContainer') as HTMLTextAreaElement?,
       options: options);
 
-  querySelector('#version')!.text = 'CodeMirror version ${CodeMirror.version}';
+  document.querySelector('#version')!.text = 'CodeMirror version ${CodeMirror.version}';
 
   Hints.registerHintsHelper('dart', _dartCompleter);
   Hints.registerHintsHelperAsync('dart', _dartCompleterAsync);
 
   // Theme control.
-  final themeSelect = querySelector('#theme') as SelectElement;
+  final themeSelect = document.querySelector('#theme') as HTMLSelectElement;
   for (final theme in CodeMirror.themes) {
-    themeSelect.children.add(OptionElement(value: theme)..text = theme);
+    themeSelect.add(HTMLOptionElement()
+      ..value = theme
+      ..text = theme);
     if (theme == editor.getTheme()) {
-      themeSelect.selectedIndex = themeSelect.length! - 1;
+      themeSelect.selectedIndex = themeSelect.length - 1;
     }
   }
   themeSelect.onChange.listen((e) {
-    var themeName = themeSelect.options[themeSelect.selectedIndex!].value;
+    var themeName = (themeSelect.options.item(themeSelect.selectedIndex) as HTMLOptionElement).value;
     editor.setTheme(themeName);
   });
 
   // Mode control.
-  final modeSelect = querySelector('#mode') as SelectElement;
+  final modeSelect = document.querySelector('#mode') as HTMLSelectElement;
   for (final mode in CodeMirror.modes) {
-    modeSelect.children.add(OptionElement(value: mode)..text = mode);
+    modeSelect.add(HTMLOptionElement()
+      ..value = mode
+      ..text = mode);
     if (mode == editor.getMode()) {
       modeSelect.selectedIndex = modeSelect.length! - 1;
     }
   }
   modeSelect.onChange.listen((e) {
-    var modeName = modeSelect.options[modeSelect.selectedIndex!].value;
+    var modeName = (modeSelect.options.item(themeSelect.selectedIndex) as HTMLOptionElement).value;
     editor.setMode(modeName);
   });
 
   // Show line numbers.
-  final lineNumbers = querySelector('#lineNumbers') as InputElement;
+  final lineNumbers = document.querySelector('#lineNumbers') as HTMLInputElement;
   lineNumbers.onChange.listen((e) {
     editor.setLineNumbers(lineNumbers.checked);
   });
 
   // Indent with tabs.
-  final tabIndent = querySelector('#tabIndent') as InputElement;
+  final tabIndent = document.querySelector('#tabIndent') as HTMLInputElement;
   tabIndent.onChange.listen((e) {
     editor.setIndentWithTabs(tabIndent.checked);
   });
@@ -102,7 +106,7 @@ void _updateFooter(CodeMirror editor) {
   var off = editor.doc.indexFromPos(pos);
   var str =
       'line ${pos.line} • column ${pos.ch} • offset $off${editor.doc.isClean() ? '' : ' • (modified)'}';
-  querySelector('#footer')!.text = str;
+  document.querySelector('#footer')!.text = str;
 }
 
 HintResults _dartCompleter(CodeMirror editor, [HintsOptions? options]) {

--- a/example/simple.dart
+++ b/example/simple.dart
@@ -56,7 +56,7 @@ void main() {
       ..value = mode
       ..text = mode);
     if (mode == editor.getMode()) {
-      modeSelect.selectedIndex = modeSelect.length! - 1;
+      modeSelect.selectedIndex = modeSelect.length - 1;
     }
   }
   modeSelect.onChange.listen((e) {

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -172,7 +172,7 @@ class CodeMirror extends ProxyHolder {
 //    // TODO: value may be a Function? always a function?
 //  }
 
-  static JsObject _createFromElement(Element element, Map? options) {
+  static JsObject _createFromElement(HTMLElement element, Map? options) {
     if (options == null) {
       return JsObject(_cm as JsFunction, [element]);
     } else {
@@ -199,7 +199,7 @@ class CodeMirror extends ProxyHolder {
 
   /// Create a new CodeMirror editor in the given element. See
   /// http://codemirror.net/doc/manual.html#config for valid options values.
-  CodeMirror.fromElement(Element element, {Map? options})
+  CodeMirror.fromElement(HTMLElement element, {Map? options})
       : super(_createFromElement(element, options)) {
     _instances[jsProxy] = this;
   }

--- a/lib/codemirror.dart
+++ b/lib/codemirror.dart
@@ -4,7 +4,7 @@
 
 library codemirror;
 
-import 'dart:html';
+import 'package:web/web.dart';
 import 'dart:js';
 
 import 'src/js_utils.dart';
@@ -181,7 +181,7 @@ class CodeMirror extends ProxyHolder {
   }
 
   static JsObject? _createFromTextArea(
-      TextAreaElement? textArea, Map? options) {
+      HTMLTextAreaElement? textArea, Map? options) {
     var args = <dynamic>[textArea];
     if (options != null) args.add(jsify(options));
     return _cm!.callMethod('fromTextArea', args);
@@ -226,7 +226,7 @@ class CodeMirror extends ProxyHolder {
   /// put into the textarea when the form is submitted. The text in the textarea
   /// will provide the content for the editor. A CodeMirror instance created this
   /// way has three additional methods: `save`, `toTextArea`, and `getTextArea`.
-  CodeMirror.fromTextArea(TextAreaElement? textArea, {Map? options})
+  CodeMirror.fromTextArea(HTMLTextAreaElement? textArea, {Map? options})
       : super(_createFromTextArea(textArea, options)) {
     _instances[jsProxy] = this;
   }
@@ -576,7 +576,7 @@ class CodeMirror extends ProxyHolder {
   ///
   /// Only available if the CodeMirror instance was created using the
   /// `CodeMirror.fromTextArea` constructor.
-  TextAreaElement? getTextArea() => call('getTextArea');
+  HTMLTextAreaElement? getTextArea() => call('getTextArea');
 
   /// If you create and discard a large number of `CodeMirror` instances, you
   /// should call [dispose] after finishing with each one.

--- a/lib/hints.dart
+++ b/lib/hints.dart
@@ -5,7 +5,7 @@
 /// A wrapper around the `hint/show-hint.js` addon.
 library codemirror.hints;
 
-import 'dart:html' show Element;
+import 'package:web/web.dart' show Element;
 import 'dart:js';
 
 import 'codemirror.dart';

--- a/lib/panel.dart
+++ b/lib/panel.dart
@@ -5,7 +5,7 @@
 /// A wrapper around the `addon/display/panel.js` addon.
 library codemirror.panel;
 
-import 'dart:html';
+import 'package:web/web.dart';
 import 'dart:js';
 
 import 'codemirror.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: codemirror
-version: 0.7.11+5.65.13
+version: 0.7.12+5.65.13
 description: A Dart wrapper around the CodeMirror text editor.
 repository: https://github.com/google/codemirror.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,5 @@ dev_dependencies:
   grinder: ^0.9.0
   lints: ^2.0.0
   test: ^1.0.0
+dependencies:
+  web: ^0.5.1

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -5,7 +5,7 @@
 @TestOn('browser')
 library codemirror.tests;
 
-import 'dart:html';
+import 'package:web/web.dart';
 
 import 'package:codemirror/codemirror.dart';
 import 'package:test/test.dart';
@@ -14,10 +14,10 @@ import 'package:test/test.dart';
 
 // TODO: document mutation
 
-final Element editorHost = DivElement();
+final Element editorHost = HTMLDivElement();
 
 void main() {
-  document.body!.children.add(editorHost);
+  document.body!.appendChild(editorHost);
 
   group('simple', createSimpleTests);
   group('CodeMirror', createCodeMirrorTests);
@@ -31,9 +31,9 @@ void createSimpleTests() {
   test('create', () {
     var editor = CodeMirror.fromElement(editorHost);
     expect(editor, isNotNull);
-    expect(editorHost.parent, isNotNull);
+    expect(editorHost.parentElement, isNotNull);
     editor.dispose();
-    editorHost.children.clear();
+    editorHost.innerHTML = '';
   });
 }
 
@@ -72,12 +72,12 @@ void createCodeMirrorTests() {
 
   tearDown(() {
     editor.dispose();
-    editorHost.children.clear();
+    editorHost.innerHTML = '';
   });
 
   test('simple', () {
     expect(editor, isNotNull);
-    expect(editorHost.parent, isNotNull);
+    expect(editorHost.parentElement, isNotNull);
   });
 
   test('getOption / setOption', () {
@@ -105,7 +105,7 @@ void createDocTests() {
 
   tearDown(() {
     editor.dispose();
-    editorHost.children.clear();
+    editorHost.innerHTML = '';
   });
 
   test('getValue / getValue', () {
@@ -193,7 +193,7 @@ void createHtmlDocTests() {
 
   tearDown(() {
     editor.dispose();
-    editorHost.children.clear();
+    editorHost.innerHTML = '';
   });
 
   test('getModeAt', () {
@@ -214,7 +214,7 @@ void createHistoryTests() {
 
   tearDown(() {
     editor.dispose();
-    editorHost.children.clear();
+    editorHost.innerHTML = '';
   });
 
   test('undo / redo', () {

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -14,7 +14,7 @@ import 'package:test/test.dart';
 
 // TODO: document mutation
 
-final Element editorHost = HTMLDivElement();
+final HTMLElement editorHost = HTMLDivElement();
 
 void main() {
   document.body!.appendChild(editorHost);

--- a/test/searchcursor_test.dart
+++ b/test/searchcursor_test.dart
@@ -5,7 +5,7 @@
 @TestOn('browser')
 library codemirror.tests;
 
-import 'dart:html';
+import 'package:web/web.dart';
 
 import 'package:codemirror/codemirror.dart';
 import 'package:test/test.dart';
@@ -20,7 +20,7 @@ void createSearchCursorTests() {
 
   setUp(() {
     editor = CodeMirror.fromTextArea(
-        querySelector('#textContainer') as TextAreaElement?);
+        document.querySelector('#textContainer') as HTMLTextAreaElement?);
   });
 
   tearDown(() {


### PR DESCRIPTION
This PR migrates `dart:html` to  `package:web` (https://dart.dev/interop/js-interop/package-web).

